### PR TITLE
UL-136 Add restart policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,12 +21,7 @@ services:
       - type: bind
         source: /srv/ul-updates-reports
         target: /srv/ul-updates-reports
-    deploy:
-      restart_policy:
-        condition: on-failure
-        delay: 30s
-        max_attempts: 5
-        window: 120s
+    restart: unless-stopped
 
   # This must use this alias in order for couchdb-lucene to use it with its default options.
   couchdb:
@@ -39,12 +34,7 @@ services:
       - type: bind
         source: /srv/docker-couchdb_data
         target: /opt/couchdb/data
-    deploy:
-      restart_policy:
-        condition: on-failure
-        delay: 30s
-        max_attempts: 5
-        window: 120s
+    restart: unless-stopped
 
   couchdb-lucene:
     image: klaemo/couchdb-lucene:2.1.0
@@ -52,12 +42,7 @@ services:
       - "5985:5985"
     depends_on:
       - couchdb
-    deploy:
-      restart_policy:
-        condition: on-failure
-        delay: 30s
-        max_attempts: 5
-        window: 120s
+    restart: unless-stopped
 
   # A "task" container which starts and immediately exits on composition build.
   # Use `docker-compose run ul-imports <npm script>` to run this container.
@@ -85,6 +70,3 @@ services:
       - type: bind
         source: /srv/ul-updates-reports
         target: /srv/ul-updates-reports
-    deploy:
-      restart_policy:
-        condition: none


### PR DESCRIPTION
Add a [restart policy](https://docs.docker.com/engine/reference/run/#restart-policies---restart) to restart the containers in the case of a failure.

I tried the policy `on-failure:5` but I saw that the exit status is 0 in the case of the process is killed, so I changed the policy to `unless-stopped` which is a bit more aggressive. 

To apply the policy:
```
docker-compose down
docker-compose up -d
``` 

To check that the policies are applied:
```
docker inspect --format "{{.HostConfig.RestartPolicy.Name}}, {{.Name}}" $(docker ps -qf status=running)
```
The output should be something similar to:
```
unless-stopped, /ul-website_ul-website_1_8e73a8bb4fd4
unless-stopped, /ul-website_couchdb-lucene_1_54819a58c8ec
unless-stopped, /ul-website_couchdb_1_287085c4e977
````